### PR TITLE
Disable dataLabels for clearer chart view

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,6 +73,9 @@
                 horizontalAlign: 'left',
                 floating: false,
             },
+            dataLabels: {
+                enabled: false
+            },
             markers: { size: 0 },
             tooltip: { x: { format: "MM/dd HH:mm" } },
             series: [],


### PR DESCRIPTION
제 눈에는 라벨을 없애는 게 더 깔끔해 보이네요.

이거 그냥 깃헙 웹 에디터로 편집한 건데
마지막 줄 바뀐 건 깃헙이 자동으로 new line 같은 거 넣었나 봐요.